### PR TITLE
Support scheduling for daylight savings

### DIFF
--- a/cronexpr.go
+++ b/cronexpr.go
@@ -160,78 +160,122 @@ func (expr *Expression) Next(fromTime time.Time) time.Time {
 		return fromTime
 	}
 
-	// Since expr.nextSecond()-expr.nextMonth() expects that the
-	// supplied time stamp is a perfect match to the underlying cron
-	// expression, and since this function is an entry point where `fromTime`
-	// does not necessarily matches the underlying cron expression,
-	// we first need to ensure supplied time stamp matches
-	// the cron expression. If not, this means the supplied time
-	// stamp falls in between matching time stamps, thus we move
-	// to closest future matching immediately upon encountering a mismatching
-	// time stamp.
+	loc := fromTime.Location()
+	t := fromTime.Add(time.Second - time.Duration(fromTime.Nanosecond())*time.Nanosecond)
 
-	// year
-	v := fromTime.Year()
-	i := sort.SearchInts(expr.yearList, v)
-	if i == len(expr.yearList) {
+WRAP:
+
+	// let's find the next date that satisfies condition
+	v := t.Year()
+	if i := sort.SearchInts(expr.yearList, v); i == len(expr.yearList) {
 		return time.Time{}
-	}
-	if v != expr.yearList[i] {
-		return expr.nextYear(fromTime)
-	}
-	// month
-	v = int(fromTime.Month())
-	i = sort.SearchInts(expr.monthList, v)
-	if i == len(expr.monthList) {
-		return expr.nextYear(fromTime)
-	}
-	if v != expr.monthList[i] {
-		return expr.nextMonth(fromTime)
+	} else if v != expr.yearList[i] {
+		t = time.Date(expr.yearList[i], time.Month(expr.monthList[0]), 1, 0, 0, 0, 0, loc)
 	}
 
-	expr.actualDaysOfMonthList = expr.calculateActualDaysOfMonth(fromTime.Year(), int(fromTime.Month()))
+	v = int(t.Month())
+	if i := sort.SearchInts(expr.monthList, v); i == len(expr.monthList) {
+		// try again with a new year
+		t = time.Date(t.Year()+1, time.Month(expr.monthList[0]), 1, 0, 0, 0, 0, loc)
+		goto WRAP
+	} else if v != expr.monthList[i] {
+		t = time.Date(t.Year(), time.Month(expr.monthList[i]), 1, 0, 0, 0, 0, loc)
+	}
+
+	expr.actualDaysOfMonthList = expr.calculateActualDaysOfMonth(t.Year(), int(t.Month()))
 	if len(expr.actualDaysOfMonthList) == 0 {
-		return expr.nextMonth(fromTime)
+		t = time.Date(t.Year(), t.Month()+1, 1, 0, 0, 0, 0, loc)
+		goto WRAP
 	}
 
-	// day of month
-	v = fromTime.Day()
-	i = sort.SearchInts(expr.actualDaysOfMonthList, v)
-	if i == len(expr.actualDaysOfMonthList) {
-		return expr.nextMonth(fromTime)
-	}
-	if v != expr.actualDaysOfMonthList[i] {
-		return expr.nextDayOfMonth(fromTime)
-	}
-	// hour
-	v = fromTime.Hour()
-	i = sort.SearchInts(expr.hourList, v)
-	if i == len(expr.hourList) {
-		return expr.nextDayOfMonth(fromTime)
-	}
-	if v != expr.hourList[i] {
-		return expr.nextHour(fromTime)
-	}
-	// minute
-	v = fromTime.Minute()
-	i = sort.SearchInts(expr.minuteList, v)
-	if i == len(expr.minuteList) {
-		return expr.nextHour(fromTime)
-	}
-	if v != expr.minuteList[i] {
-		return expr.nextMinute(fromTime)
-	}
-	// second
-	v = fromTime.Second()
-	i = sort.SearchInts(expr.secondList, v)
-	if i == len(expr.secondList) {
-		return expr.nextMinute(fromTime)
+	v = t.Day()
+	if i := sort.SearchInts(expr.actualDaysOfMonthList, v); i == len(expr.actualDaysOfMonthList) {
+		t = time.Date(t.Year(), t.Month()+1, 1, 0, 0, 0, 0, loc)
+		goto WRAP
+	} else if v != expr.actualDaysOfMonthList[i] {
+		t = time.Date(t.Year(), t.Month(), expr.actualDaysOfMonthList[i], 0, 0, 0, 0, loc)
+
+		// in San Palo, before 2019, there may be no midnight (or multiple midnights)
+		// due to DST
+		if t.Hour() != 0 {
+			if t.Hour() > 12 {
+				t = t.Add(time.Duration(24-t.Hour()) * time.Hour)
+			} else {
+				t = t.Add(time.Duration(-t.Hour()) * time.Hour)
+			}
+		}
 	}
 
-	// If we reach this point, there is nothing better to do
-	// than to move to the next second
+	if timeZoneInDay(t) {
+		goto SLOW_CLOCK
+	}
 
-	return expr.nextSecond(fromTime)
+	// Fast path where hours/minutes behave as expected trivially
+	v = t.Hour()
+	if i := sort.SearchInts(expr.hourList, v); i == len(expr.hourList) {
+		t = time.Date(t.Year(), t.Month(), t.Day()+1, 0, 0, 0, 0, loc)
+		goto WRAP
+	} else if v != expr.hourList[i] {
+		t = time.Date(t.Year(), t.Month(), t.Day(), expr.hourList[i], expr.minuteList[0], expr.secondList[0], 0, loc)
+	}
+
+	v = t.Minute()
+	if i := sort.SearchInts(expr.minuteList, v); i == len(expr.minuteList) {
+		t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour()+1, 0, 0, 0, loc)
+		goto WRAP
+	} else if v != expr.minuteList[i] {
+		t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), expr.minuteList[i], expr.secondList[0], 0, loc)
+	}
+
+	v = t.Second()
+	if i := sort.SearchInts(expr.secondList, v); i == len(expr.secondList) {
+		t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute()+1, 0, 0, loc)
+		goto WRAP
+	} else if v != expr.secondList[i] {
+		t = time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), t.Minute(), expr.secondList[i], 0, loc)
+	}
+
+	return t
+
+SLOW_CLOCK:
+	// daylight saving effect is here, where odd things happen:
+	// An hour may have 60 minutes, 30 minutes or 90 minutes;
+	// partial hours may "repeat"!
+	for !sortContains(expr.hourList, t.Hour()) {
+		hourBefore := t.Hour()
+		t = t.Add(time.Hour)
+		if hourBefore == t.Hour() {
+			t = t.Add(time.Hour)
+		}
+		t = t.Truncate(time.Minute)
+		if t.Minute() != 0 {
+			t = t.Add(-1 * time.Minute * time.Duration(t.Minute()))
+		}
+
+		if t.Hour() == 0 {
+			t = time.Date(t.Year(), t.Month(), t.Day(), 0, 0, 0, 0, loc)
+			goto WRAP
+		}
+	}
+
+	for !sortContains(expr.minuteList, t.Minute()) {
+		hoursBefore := t.Hour()
+		t = t.Truncate(time.Minute).Add(time.Minute)
+		if hoursBefore != t.Hour() {
+			goto WRAP
+		}
+	}
+
+	v = t.Second()
+	t = t.Truncate(time.Minute)
+	if i := sort.SearchInts(expr.secondList, v); i == len(expr.secondList) {
+		t = t.Add(time.Minute)
+		goto WRAP
+	} else {
+		t = t.Add(time.Duration(expr.secondList[i]) * time.Second)
+	}
+
+	return t
 }
 
 /******************************************************************************/
@@ -259,7 +303,7 @@ func (expr *Expression) NextN(fromTime time.Time, n uint) []time.Time {
 			if n == 0 {
 				break
 			}
-			fromTime = expr.nextSecond(fromTime)
+			fromTime = expr.Next(fromTime)
 		}
 	}
 	return nextTimes

--- a/cronexpr_next.go
+++ b/cronexpr_next.go
@@ -33,160 +33,6 @@ var dowNormalizedOffsets = [][]int{
 
 /******************************************************************************/
 
-func (expr *Expression) nextYear(t time.Time) time.Time {
-	// Find index at which item in list is greater or equal to
-	// candidate year
-	i := sort.SearchInts(expr.yearList, t.Year()+1)
-	if i == len(expr.yearList) {
-		return time.Time{}
-	}
-	// Year changed, need to recalculate actual days of month
-	expr.actualDaysOfMonthList = expr.calculateActualDaysOfMonth(expr.yearList[i], expr.monthList[0])
-	if len(expr.actualDaysOfMonthList) == 0 {
-		return expr.nextMonth(time.Date(
-			expr.yearList[i],
-			time.Month(expr.monthList[0]),
-			1,
-			expr.hourList[0],
-			expr.minuteList[0],
-			expr.secondList[0],
-			0,
-			t.Location()))
-	}
-	return time.Date(
-		expr.yearList[i],
-		time.Month(expr.monthList[0]),
-		expr.actualDaysOfMonthList[0],
-		expr.hourList[0],
-		expr.minuteList[0],
-		expr.secondList[0],
-		0,
-		t.Location())
-}
-
-/******************************************************************************/
-
-func (expr *Expression) nextMonth(t time.Time) time.Time {
-	// Find index at which item in list is greater or equal to
-	// candidate month
-	i := sort.SearchInts(expr.monthList, int(t.Month())+1)
-	if i == len(expr.monthList) {
-		return expr.nextYear(t)
-	}
-	// Month changed, need to recalculate actual days of month
-	expr.actualDaysOfMonthList = expr.calculateActualDaysOfMonth(t.Year(), expr.monthList[i])
-	if len(expr.actualDaysOfMonthList) == 0 {
-		return expr.nextMonth(time.Date(
-			t.Year(),
-			time.Month(expr.monthList[i]),
-			1,
-			expr.hourList[0],
-			expr.minuteList[0],
-			expr.secondList[0],
-			0,
-			t.Location()))
-	}
-
-	return time.Date(
-		t.Year(),
-		time.Month(expr.monthList[i]),
-		expr.actualDaysOfMonthList[0],
-		expr.hourList[0],
-		expr.minuteList[0],
-		expr.secondList[0],
-		0,
-		t.Location())
-}
-
-/******************************************************************************/
-
-func (expr *Expression) nextDayOfMonth(t time.Time) time.Time {
-	// Find index at which item in list is greater or equal to
-	// candidate day of month
-	i := sort.SearchInts(expr.actualDaysOfMonthList, t.Day()+1)
-	if i == len(expr.actualDaysOfMonthList) {
-		return expr.nextMonth(t)
-	}
-
-	return time.Date(
-		t.Year(),
-		t.Month(),
-		expr.actualDaysOfMonthList[i],
-		expr.hourList[0],
-		expr.minuteList[0],
-		expr.secondList[0],
-		0,
-		t.Location())
-}
-
-/******************************************************************************/
-
-func (expr *Expression) nextHour(t time.Time) time.Time {
-	// Find index at which item in list is greater or equal to
-	// candidate hour
-	i := sort.SearchInts(expr.hourList, t.Hour()+1)
-	if i == len(expr.hourList) {
-		return expr.nextDayOfMonth(t)
-	}
-
-	return time.Date(
-		t.Year(),
-		t.Month(),
-		t.Day(),
-		expr.hourList[i],
-		expr.minuteList[0],
-		expr.secondList[0],
-		0,
-		t.Location())
-}
-
-/******************************************************************************/
-
-func (expr *Expression) nextMinute(t time.Time) time.Time {
-	// Find index at which item in list is greater or equal to
-	// candidate minute
-	i := sort.SearchInts(expr.minuteList, t.Minute()+1)
-	if i == len(expr.minuteList) {
-		return expr.nextHour(t)
-	}
-
-	return time.Date(
-		t.Year(),
-		t.Month(),
-		t.Day(),
-		t.Hour(),
-		expr.minuteList[i],
-		expr.secondList[0],
-		0,
-		t.Location())
-}
-
-/******************************************************************************/
-
-func (expr *Expression) nextSecond(t time.Time) time.Time {
-	// nextSecond() assumes all other fields are exactly matched
-	// to the cron expression
-
-	// Find index at which item in list is greater or equal to
-	// candidate second
-	i := sort.SearchInts(expr.secondList, t.Second()+1)
-	if i == len(expr.secondList) {
-		return expr.nextMinute(t)
-	}
-
-	return time.Date(
-		t.Year(),
-		t.Month(),
-		t.Day(),
-		t.Hour(),
-		t.Minute(),
-		expr.secondList[i],
-		0,
-		t.Location())
-}
-
-/******************************************************************************/
-
 func (expr *Expression) calculateActualDaysOfMonth(year, month int) []int {
 	actualDaysOfMonthMap := make(map[int]bool)
 	firstDayOfMonth := time.Date(year, time.Month(month), 1, 0, 0, 0, 0, time.UTC)
@@ -289,4 +135,19 @@ func workdayOfMonth(targetDom, lastDom time.Time) int {
 		}
 	}
 	return dom
+}
+
+func sortContains(a []int, x int) bool {
+	i := sort.SearchInts(a, x)
+	return i < len(a) && a[i] == x
+}
+
+func timeZoneInDay(t time.Time) bool {
+	if t.Location() == time.UTC {
+		return false
+	}
+
+	_, off := t.AddDate(0, 0, -1).Zone()
+	_, ndoff := t.AddDate(0, 0, 1).Zone()
+	return off != ndoff
 }

--- a/cronexpr_test.go
+++ b/cronexpr_test.go
@@ -15,8 +15,12 @@ package cronexpr
 /******************************************************************************/
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 /******************************************************************************/
@@ -278,6 +282,493 @@ func TestNextN_every5min(t *testing.T) {
 		if nextStr != expected[i] {
 			t.Errorf(`MustParse("*/5 * * * *").NextN("2013-09-02 08:44:30", 5):\n"`)
 			t.Errorf(`  result[%d]: expected "%s" but got "%s"`, i, expected[i], nextStr)
+		}
+	}
+}
+
+func TestPeriodicConfig_DSTChange_Transitions(t *testing.T) {
+	locName := "America/Los_Angeles"
+	loc, err := time.LoadLocation(locName)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		pattern  string
+		initTime time.Time
+		expected []time.Time
+	}{
+		{
+			"normal time",
+			"0 2 * * * 2019",
+			time.Date(2019, time.February, 7, 1, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.February, 7, 2, 0, 0, 0, loc),
+				time.Date(2019, time.February, 8, 2, 0, 0, 0, loc),
+				time.Date(2019, time.February, 9, 2, 0, 0, 0, loc),
+			},
+		},
+		{
+			"Spring forward but not in switch time",
+			"0 4 * * * 2019",
+			time.Date(2019, time.March, 9, 1, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.March, 9, 4, 0, 0, 0, loc),
+				time.Date(2019, time.March, 10, 4, 0, 0, 0, loc),
+				time.Date(2019, time.March, 11, 4, 0, 0, 0, loc),
+			},
+		},
+		{
+			"Spring forward at a skipped time odd",
+			"2 2 * * * 2019",
+			time.Date(2019, time.March, 9, 1, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.March, 9, 2, 2, 0, 0, loc),
+				// no time in March 10!
+				time.Date(2019, time.March, 11, 2, 2, 0, 0, loc),
+				time.Date(2019, time.March, 12, 2, 2, 0, 0, loc),
+			},
+		},
+		{
+			"Spring forward at a skipped time",
+			"1 2 * * * 2019",
+			time.Date(2019, time.March, 9, 1, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.March, 9, 2, 1, 0, 0, loc),
+				// no time in March 8!
+				time.Date(2019, time.March, 11, 2, 1, 0, 0, loc),
+				time.Date(2019, time.March, 12, 2, 1, 0, 0, loc),
+			},
+		},
+		{
+			"Spring forward at a skipped time boundary",
+			"0 2 * * * 2019",
+			time.Date(2019, time.March, 9, 1, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.March, 9, 2, 0, 0, 0, loc),
+				// no time in March 8!
+				time.Date(2019, time.March, 11, 2, 0, 0, 0, loc),
+				time.Date(2019, time.March, 12, 2, 0, 0, 0, loc),
+			},
+		},
+		{
+			"Spring forward at a boundary of repeating time",
+			"0 1 * * * 2019",
+			time.Date(2019, time.March, 9, 0, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.March, 9, 1, 0, 0, 0, loc),
+				time.Date(2019, time.March, 10, 0, 0, 0, 0, loc).Add(1 * time.Hour),
+				time.Date(2019, time.March, 11, 1, 0, 0, 0, loc),
+				time.Date(2019, time.March, 12, 1, 0, 0, 0, loc),
+			},
+		},
+		{
+			"Fall back: before transition",
+			"30 0 * * * 2019",
+			time.Date(2019, time.November, 3, 0, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.November, 3, 0, 30, 0, 0, loc),
+				time.Date(2019, time.November, 4, 0, 30, 0, 0, loc),
+				time.Date(2019, time.November, 5, 0, 30, 0, 0, loc),
+				time.Date(2019, time.November, 6, 0, 30, 0, 0, loc),
+			},
+		},
+		{
+			"Fall back: after transition",
+			"30 3 * * * 2019",
+			time.Date(2019, time.November, 3, 0, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.November, 3, 3, 30, 0, 0, loc),
+				time.Date(2019, time.November, 4, 3, 30, 0, 0, loc),
+				time.Date(2019, time.November, 5, 3, 30, 0, 0, loc),
+				time.Date(2019, time.November, 6, 3, 30, 0, 0, loc),
+			},
+		},
+		{
+			"Fall back: after transition starting in repeated span before",
+			"30 3 * * * 2019",
+			time.Date(2019, time.November, 3, 0, 10, 0, 0, loc).Add(1 * time.Hour),
+			[]time.Time{
+				time.Date(2019, time.November, 3, 3, 30, 0, 0, loc),
+				time.Date(2019, time.November, 4, 3, 30, 0, 0, loc),
+				time.Date(2019, time.November, 5, 3, 30, 0, 0, loc),
+				time.Date(2019, time.November, 6, 3, 30, 0, 0, loc),
+			},
+		},
+		{
+			"Fall back: after transition starting in repeated span after",
+			"30 3 * * * 2019",
+			time.Date(2019, time.November, 3, 0, 10, 0, 0, loc).Add(2 * time.Hour),
+			[]time.Time{
+				time.Date(2019, time.November, 3, 3, 30, 0, 0, loc),
+				time.Date(2019, time.November, 4, 3, 30, 0, 0, loc),
+				time.Date(2019, time.November, 5, 3, 30, 0, 0, loc),
+				time.Date(2019, time.November, 6, 3, 30, 0, 0, loc),
+			},
+		},
+		{
+			"Fall back: in repeated region",
+			"30 1 * * * 2019",
+			time.Date(2019, time.November, 3, 0, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.November, 3, 0, 30, 0, 0, loc).Add(1 * time.Hour),
+				time.Date(2019, time.November, 3, 0, 30, 0, 0, loc).Add(2 * time.Hour),
+				time.Date(2019, time.November, 4, 1, 30, 0, 0, loc),
+				time.Date(2019, time.November, 5, 1, 30, 0, 0, loc),
+				time.Date(2019, time.November, 6, 1, 30, 0, 0, loc),
+			},
+		},
+		{
+			"Fall back: in repeated region boundary",
+			"0 1 * * * 2019",
+			time.Date(2019, time.November, 3, 0, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.November, 3, 0, 0, 0, 0, loc).Add(1 * time.Hour),
+				time.Date(2019, time.November, 3, 0, 0, 0, 0, loc).Add(2 * time.Hour),
+				time.Date(2019, time.November, 4, 1, 0, 0, 0, loc),
+				time.Date(2019, time.November, 5, 1, 0, 0, 0, loc),
+				time.Date(2019, time.November, 6, 1, 0, 0, 0, loc),
+			},
+		},
+		{
+			"Fall back: in repeated region boundary 2",
+			"0 2 * * * 2019",
+			time.Date(2019, time.November, 3, 0, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.November, 3, 0, 0, 0, 0, loc).Add(3 * time.Hour),
+				time.Date(2019, time.November, 4, 2, 0, 0, 0, loc),
+				time.Date(2019, time.November, 5, 2, 0, 0, 0, loc),
+				time.Date(2019, time.November, 6, 2, 0, 0, 0, loc),
+			},
+		},
+		{
+			"Fall back: in repeated region, starting from within region",
+			"30 1 * * * 2019",
+			time.Date(2019, time.November, 3, 0, 40, 0, 0, loc).Add(1 * time.Hour),
+			[]time.Time{
+				time.Date(2019, time.November, 3, 0, 30, 0, 0, loc).Add(2 * time.Hour),
+				time.Date(2019, time.November, 4, 1, 30, 0, 0, loc),
+				time.Date(2019, time.November, 5, 1, 30, 0, 0, loc),
+				time.Date(2019, time.November, 6, 1, 30, 0, 0, loc),
+			},
+		},
+		{
+			"Fall back: in repeated region, starting from within region 2",
+			"30 1 * * * 2019",
+			time.Date(2019, time.November, 3, 0, 40, 0, 0, loc).Add(2 * time.Hour),
+			[]time.Time{
+				time.Date(2019, time.November, 4, 1, 30, 0, 0, loc),
+				time.Date(2019, time.November, 5, 1, 30, 0, 0, loc),
+				time.Date(2019, time.November, 6, 1, 30, 0, 0, loc),
+			},
+		},
+		{
+			"Fall back: wildcard",
+			"30 * * * * 2019",
+			time.Date(2019, time.November, 3, 0, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.November, 3, 0, 30, 0, 0, loc),
+				time.Date(2019, time.November, 3, 0, 30, 0, 0, loc).Add(1 * time.Hour),
+				time.Date(2019, time.November, 3, 0, 30, 0, 0, loc).Add(2 * time.Hour),
+				time.Date(2019, time.November, 3, 2, 30, 0, 0, loc),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			expr := MustParse(c.pattern)
+
+			starting := c.initTime
+			for _, next := range c.expected {
+				n := expr.Next(starting)
+				if next != n {
+					t.Fatalf("next(%v) = %v not %v", starting, next, n)
+				}
+
+				starting = next
+			}
+		})
+	}
+}
+
+func TestPeriodicConfig_DSTChange_Transitions_LordHowe(t *testing.T) {
+	locName := "Australia/Lord_Howe"
+	loc, err := time.LoadLocation(locName)
+	require.NoError(t, err)
+
+	cases := []struct {
+		name     string
+		pattern  string
+		initTime time.Time
+		expected []time.Time
+	}{
+		{
+			"normal time",
+			"0 2 * * * 2019",
+			time.Date(2019, time.February, 7, 1, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.February, 7, 2, 0, 0, 0, loc),
+				time.Date(2019, time.February, 8, 2, 0, 0, 0, loc),
+				time.Date(2019, time.February, 9, 2, 0, 0, 0, loc),
+			},
+		},
+		{
+			"backward: non repeated portion of the hour",
+			"3 1 * * * 2019",
+			time.Date(2019, time.April, 6, 0, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.April, 6, 1, 3, 0, 0, loc),
+				time.Date(2019, time.April, 7, 1, 3, 0, 0, loc),
+				time.Date(2019, time.April, 8, 1, 3, 0, 0, loc),
+				time.Date(2019, time.April, 9, 1, 3, 0, 0, loc),
+			},
+		},
+		{
+			"backward: repeated portion of the hour",
+			"31 1 * * * 2019",
+			time.Date(2019, time.April, 6, 0, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.April, 6, 1, 31, 0, 0, loc),
+				time.Date(2019, time.April, 7, 0, 31, 0, 0, loc).Add(60 * time.Minute),
+				time.Date(2019, time.April, 7, 0, 31, 0, 0, loc).Add(90 * time.Minute),
+				time.Date(2019, time.April, 8, 1, 31, 0, 0, loc),
+				time.Date(2019, time.April, 9, 1, 31, 0, 0, loc),
+			},
+		},
+		{
+			"forward: skipped portion of the hour",
+			"3 2 * * * 2019",
+			time.Date(2019, time.October, 5, 0, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.October, 5, 2, 3, 0, 0, loc),
+				// no Oct 6
+				time.Date(2019, time.October, 7, 2, 3, 0, 0, loc),
+				time.Date(2019, time.October, 8, 2, 3, 0, 0, loc),
+				time.Date(2019, time.October, 9, 2, 3, 0, 0, loc),
+			},
+		},
+		{
+			"forward: non-skipped portion of the hour",
+			"31 2 * * * 2019",
+			time.Date(2019, time.October, 5, 0, 0, 0, 0, loc),
+			[]time.Time{
+				time.Date(2019, time.October, 5, 2, 31, 0, 0, loc),
+				// no Oct 6
+				time.Date(2019, time.October, 7, 2, 31, 0, 0, loc),
+				time.Date(2019, time.October, 8, 2, 31, 0, 0, loc),
+				time.Date(2019, time.October, 9, 2, 31, 0, 0, loc),
+			},
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			expr := MustParse(c.pattern)
+
+			starting := c.initTime
+			for _, next := range c.expected {
+				n := expr.Next(starting)
+				if next != n {
+					t.Fatalf("next(%v) = %v not %v", starting, next, n)
+				}
+
+				starting = next
+			}
+		})
+	}
+}
+
+func TestNext_DaylightSaving_Property(t *testing.T) {
+	locName := "America/Los_Angeles"
+	loc, err := time.LoadLocation(locName)
+	if err != nil {
+		t.Fatalf("failed to get location: %v", err)
+	}
+
+	cronExprs := []string{
+		"* * * * *",
+		"0 2 * * *",
+		"* 1 * * *",
+	}
+
+	times := []time.Time{
+		// spring forward
+		time.Date(2019, time.March, 11, 0, 0, 0, 0, loc),
+		time.Date(2019, time.March, 10, 0, 0, 0, 0, loc),
+		time.Date(2019, time.March, 11, 0, 0, 0, 0, loc),
+
+		// leap backwards
+		time.Date(2019, time.November, 4, 0, 0, 0, 0, loc),
+		time.Date(2019, time.November, 5, 0, 0, 0, 0, loc),
+		time.Date(2019, time.November, 6, 0, 0, 0, 0, loc),
+	}
+
+	testSpan := 4 * time.Hour
+
+	testCase := func(t *testing.T, cronExpr string, init time.Time) {
+		cron := MustParse(cronExpr)
+
+		prevNext := init
+		for start := init; start.Before(init.Add(testSpan)); start = start.Add(1 * time.Minute) {
+			next := cron.Next(start)
+			if !next.After(start) {
+				t.Fatalf("next(%v) = %v is not after start time", start, next)
+			}
+
+			if next.Before(prevNext) {
+				t.Fatalf("next(%v) = %v reverted back in time from %v", start, next, prevNext)
+			}
+
+			if strings.HasPrefix(cronExpr, "* * ") {
+				if next.Sub(start) != time.Minute {
+					t.Fatalf("next(%v) = %v should be the next minute", start, next)
+				}
+			}
+
+			prevNext = next
+		}
+	}
+
+	for _, cron := range cronExprs {
+		for _, startTime := range times {
+			t.Run(fmt.Sprintf("%v: %v", cron, startTime), func(t *testing.T) {
+				testCase(t, cron, startTime)
+			})
+		}
+	}
+}
+
+func TestNext_DaylightSaving_Property_LordHowe(t *testing.T) {
+	// Lord Howe, Australia is at GMT+1100 April-October and GMT+1030 otherwise.
+	//
+	// On April 7, 2019, at when clock approches 2am, the clock
+	// transitions to 1.30am.
+	//
+	// On October 6, when the clock approaches 2am, the clock transitions
+	// to 2.30am.
+	locName := "Australia/Lord_Howe"
+	loc, err := time.LoadLocation(locName)
+	if err != nil {
+		t.Fatalf("failed to get location: %v", err)
+	}
+
+	cronExprs := []string{
+		"* * * * *",
+		"0 2 * * *",
+		"* 1 * * *",
+		"35 1 * * *",
+		"5 2 * * *",
+	}
+
+	times := []time.Time{
+		// spring forward
+		time.Date(2019, time.April, 6, 0, 0, 0, 0, loc),
+		time.Date(2019, time.April, 7, 0, 0, 0, 0, loc),
+		time.Date(2019, time.April, 8, 0, 0, 0, 0, loc),
+
+		// leap backwards
+		time.Date(2019, time.October, 5, 0, 0, 0, 0, loc),
+		time.Date(2019, time.October, 6, 0, 0, 0, 0, loc),
+		time.Date(2019, time.October, 7, 0, 0, 0, 0, loc),
+	}
+
+	testSpan := 4 * time.Hour
+
+	testCase := func(t *testing.T, cronExpr string, init time.Time) {
+		cron := MustParse(cronExpr)
+
+		prevNext := init
+		for start := init; start.Before(init.Add(testSpan)); start = start.Add(1 * time.Minute) {
+			next := cron.Next(start)
+			if !next.After(start) {
+				t.Fatalf("next(%v) = %v is not after start time", start, next)
+			}
+
+			if next.Before(prevNext) {
+				t.Fatalf("next(%v) = %v reverted back in time from %v", start, next, prevNext)
+			}
+
+			if strings.HasPrefix(cronExpr, "* * ") {
+				if next.Sub(start) != time.Minute {
+					t.Fatalf("next(%v) = %v should be the next minute", start, next)
+				}
+			}
+
+			prevNext = next
+		}
+	}
+
+	for _, cron := range cronExprs {
+		for _, startTime := range times {
+			t.Run(fmt.Sprintf("%v: %v", cron, startTime), func(t *testing.T) {
+				testCase(t, cron, startTime)
+			})
+		}
+	}
+}
+
+func TestNext_DaylightSaving_Property_Brazil(t *testing.T) {
+	// Until 2018, Brazil/Sao Paulo and some South American countries used
+	// to transition for daylight savings at midnight.
+	//
+	// When the clock approaches 2018-11-04 midnight, the clock transitions to 1am.
+	locName := "America/Sao_Paulo"
+	loc, err := time.LoadLocation(locName)
+	if err != nil {
+		t.Fatalf("failed to get location: %v", err)
+	}
+
+	cronExprs := []string{
+		"* * * * *",
+		"0 2 * * *",
+		"* 1 * * *",
+		"5 1 * * *",
+		"5 23 * * *",
+	}
+
+	times := []time.Time{
+		// spring forward
+		time.Date(2018, time.February, 16, 22, 0, 0, 0, loc),
+		time.Date(2018, time.February, 17, 22, 0, 0, 0, loc),
+		time.Date(2018, time.February, 18, 22, 0, 0, 0, loc),
+
+		// leap backwards
+		time.Date(2018, time.November, 3, 23, 0, 0, 0, loc),
+		time.Date(2018, time.November, 3, 23, 0, 0, 0, loc),
+		time.Date(2018, time.November, 3, 23, 0, 0, 0, loc),
+	}
+
+	testSpan := 4 * time.Hour
+
+	testCase := func(t *testing.T, cronExpr string, init time.Time) {
+		cron := MustParse(cronExpr)
+
+		prevNext := init
+		for start := init; start.Before(init.Add(testSpan)); start = start.Add(1 * time.Minute) {
+			next := cron.Next(start)
+			if !next.After(start) {
+				t.Fatalf("next(%v) = %v is not after start time", start, next)
+			}
+
+			if next.Before(prevNext) {
+				t.Fatalf("next(%v) = %v reverted back in time from %v", start, next, prevNext)
+			}
+
+			if strings.HasPrefix(cronExpr, "* * ") {
+				if next.Sub(start) != time.Minute {
+					t.Fatalf("next(%v) = %v should be the next minute", start, next)
+				}
+			}
+
+			prevNext = next
+		}
+	}
+
+	for _, cron := range cronExprs {
+		for _, startTime := range times {
+			t.Run(fmt.Sprintf("%v: %v", cron, startTime), func(t *testing.T) {
+				testCase(t, cron, startTime)
+			})
 		}
 	}
 }


### PR DESCRIPTION
This adds support for daylight savings into the library, in the
following form:

* If the cronexpr isn't satisfied on a day due to leap forward, the day
will be skipped.
  * `30 2 * * *` will not match anytime on 2019-03-10 US/New_York

* If an hour is "repeated" due to daylight savings backward transition,
the day may have multiple matches
  * `30 1 * * *` will match twice on 2019-11-03 US/New_York

Every second cron expressions will match every second during transition.
So will hourly expressions.