### PR TITLE
Update godoc link

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ returned.
 
 API
 ---
-<http://godoc.org/github.com/gorhill/cronexpr>
+<https://pkg.go.dev/github.com/hashicorp/cronexpr>
 
 License
 -------


### PR DESCRIPTION
Now that the license checking works, it would be nice to point to the right godoc link (the gorhill link just shows a license check error)